### PR TITLE
feat: Enable gocyclo linter and reduce complexity in test functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,85 +12,76 @@ linters:
   disable:
     - staticcheck  # Disabled: QF1008 warnings are low-priority style suggestions
 
-linters-settings:
-  gofumpt:
-    lang-version: "1.21"
-    extra-rules: true
-  revive:
-    enable-all-rules: false
+  settings:
+    revive:
+      enable-all-rules: false
+      rules:
+        - name: var-naming
+          disabled: false
+        - name: package-comments
+          disabled: true
+    gocyclo:
+      min-complexity: 16
+    cyclop:
+      max-complexity: 15
+
+  exclusions:
     rules:
-      - name: var-naming
-        disabled: false
-      - name: package-comments
-        disabled: true
-  gocyclo:
-    min-complexity: 15
-  cyclop:
-    max-complexity: 15
-    skip-tests: true
+      # Exclude all linter errors from test files
+      - path: _test\.go$
+        linters:
+          - errcheck
+          - revive
+          - staticcheck
+
+      # Exclude all linter errors from examples (except cyclomatic complexity)
+      - path: examples/
+        linters:
+          - errcheck
+          - revive
+          - staticcheck
+          - govet
+
+      # Exclude all linter errors from internal test utilities
+      - path: internal/testutil/
+        linters:
+          - errcheck
+          - revive
+          - staticcheck
+
+      # Allow printf format directives in example code (examples demonstrate Printf usage)
+      - text: "fmt.Print call has possible Printf formatting directive"
+        linters:
+          - govet
+
+      # Allow SSEHandler name (stuttering is intentional for clarity)
+      - text: "type name will be used as sse.SSEHandler"
+        linters:
+          - revive
+
+      # Allow explicit embedded field access (clearer than implicit)
+      - text: "QF1008"
+        linters:
+          - staticcheck
+
+      # Allow SSE stuttering name export
+      - text: "exported.*stutters"
+        linters:
+          - revive
 
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
 
-  exclude-rules:
-    # Exclude all linter errors from test files
-    - path: _test\.go$
-      linters:
-        - errcheck
-        - revive
-        - staticcheck
-
-    # Exclude all linter errors from examples (except cyclomatic complexity)
-    - path: examples/
-      linters:
-        - errcheck
-        - revive
-        - staticcheck
-        - govet
-
-    # Exclude all linter errors from internal test utilities
-    - path: internal/testutil/
-      linters:
-        - errcheck
-        - revive
-        - staticcheck
-
-    # Allow printf format directives in example code (examples demonstrate Printf usage)
-    - text: "fmt.Print call has possible Printf formatting directive"
-      linters:
-        - govet
-
-    # Allow SSEHandler name (stuttering is intentional for clarity)
-    - text: "type name will be used as sse.SSEHandler"
-      linters:
-        - revive
-
-    # Allow explicit embedded field access (clearer than implicit)
-    - text: "QF1008"
-      linters:
-        - staticcheck
-
-    # Allow SSE stuttering name export
-    - text: "exported.*stutters"
-      linters:
-        - revive
-
 run:
   timeout: 5m
-  tests: false  # Don't run linters on test files
-  skip-dirs:
-    - vendor
-    - examples
+  tests: true  # Run linters on test files to catch cyclomatic complexity
 
 output:
-  formats:
-    colored-line-number:
-      path: stdout
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
+  sort-order:
+    - linter
+    - severity
+    - file
 
 severity:
-  default-severity: error
+  default: error

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
         - name: package-comments
           disabled: true
     gocyclo:
-      min-complexity: 16
+      min-complexity: 15
     cyclop:
       max-complexity: 15
 


### PR DESCRIPTION
## Summary

Enable gocyclo linter to detect high cyclomatic complexity and refactor test functions that exceeded the threshold.

## Changes

### Linter Configuration
- Updated `.golangci.yml` to v2 format
- Enabled `gocyclo` with threshold 15 (detects complexity > 15)
- Enabled `cyclop` with max complexity 15
- Set `run.tests: true` to include test files in linting
- Migrated configuration structure:
  - `linters-settings` → `linters.settings`
  - `exclude-rules` → `linters.exclusions.rules`

### Code Refactoring

**mcp/types_test.go** - `TestPromptMessageUnmarshalJSON`
- Reduced complexity from 49 to 6
- Extracted 9 helper functions for content verification
- All test cases now call named helper functions

**test/integration/protocol_test.go** - `testProtocolOperations`
- Reduced complexity from 21 to 3
- Extracted 6 helper functions for protocol operations
- Improved readability and maintainability

## Testing

- ✅ All tests pass: `go test ./...`
- ✅ Linter passes with 0 issues: `golangci-lint run ./...`
- ✅ Configuration validated: `golangci-lint config verify`

## Impact

This ensures future code maintains reasonable complexity levels, making the codebase more maintainable and easier to test.