### PR TITLE
feat: update release workflow with changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,20 +51,33 @@ jobs:
           git tag -a v${{ steps.semver.outputs.version }} -m "Release v${{ steps.semver.outputs.version }}"
           git push origin v${{ steps.semver.outputs.version }}
 
+      - name: Generate Changelog
+        if: steps.semver.outputs.changed == 'true'
+        id: changelog
+        run: |
+          echo "## Changes in v${{ steps.semver.outputs.version }}" > CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          if [ -n "${{ steps.semver.outputs.previous_version }}" ]; then
+            echo "### Commits since v${{ steps.semver.outputs.previous_version }}" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log v${{ steps.semver.outputs.previous_version }}..HEAD --pretty=format:"- %s (%h)" --no-merges >> CHANGELOG.md || \
+            git log --pretty=format:"- %s (%h)" --no-merges -n 20 >> CHANGELOG.md
+          else
+            echo "### Initial Release" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log --pretty=format:"- %s (%h)" --no-merges -n 20 >> CHANGELOG.md
+          fi
+          echo "" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/v${{ steps.semver.outputs.previous_version }}...v${{ steps.semver.outputs.version }}" >> CHANGELOG.md
+
       - name: Create GitHub Release
         if: steps.semver.outputs.changed == 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.semver.outputs.version }}
-          release_name: Release v${{ steps.semver.outputs.version }}
-          body: |
-            ## Changes in v${{ steps.semver.outputs.version }}
-
-            Version: ${{ steps.semver.outputs.version }}
-            Previous Version: ${{ steps.semver.outputs.previous_version }}
-
-            See commit history for details.
+          name: Release v${{ steps.semver.outputs.version }}
+          body_path: CHANGELOG.md
           draft: false
           prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Replace deprecated actions/create-release@v1 with softprops/action-gh-release@v2
- Add automated changelog generation from git commits
- Enable auto-generated release notes
- Include commit history since previous version in release description

## Changes
- **Generate Changelog step**: Creates CHANGELOG.md with commits since previous version
- **Updated release action**: Uses latest softprops/action-gh-release@v2
- **Auto-generated notes**: Enables GitHub's built-in release notes generation
- **Better release descriptions**: Actual commit messages instead of generic text

## Test plan
- Verify workflow syntax is valid
- Test on next release to ensure changelog is properly generated