### PR TITLE
docs: fix broken link and add coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmcarbo/fullmcp.svg)](https://pkg.go.dev/github.com/jmcarbo/fullmcp)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jmcarbo/fullmcp)](https://goreportcard.com/report/github.com/jmcarbo/fullmcp)
-[![Coverage](https://img.shields.io/badge/coverage-95.8%25-brightgreen)](https://github.com/jmcarbo/fullmcp)
+[![codecov](https://codecov.io/gh/jmcarbo/fullmcp/branch/main/graph/badge.svg)](https://codecov.io/gh/jmcarbo/fullmcp)
 
 A comprehensive, production-ready Golang implementation of the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) with full support for tools, resources, prompts, and multiple transport mechanisms.
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,8 @@ See [benchmarks](./docs/benchmarks.md) for detailed performance analysis.
 - ✅ Performance benchmarked
 - ✅ Used in production environments
 
+See [IMPLEMENTATION_STATUS.md](./docs/IMPLEMENTATION_STATUS.md) for detailed feature tracking.
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmcarbo/fullmcp.svg)](https://pkg.go.dev/github.com/jmcarbo/fullmcp)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jmcarbo/fullmcp)](https://goreportcard.com/report/github.com/jmcarbo/fullmcp)
+[![Coverage](https://img.shields.io/badge/coverage-95.8%25-brightgreen)](https://github.com/jmcarbo/fullmcp)
 
 A comprehensive, production-ready Golang implementation of the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) with full support for tools, resources, prompts, and multiple transport mechanisms.
 
@@ -486,8 +487,6 @@ See [benchmarks](./docs/benchmarks.md) for detailed performance analysis.
 - ✅ Comprehensive integration tests
 - ✅ Performance benchmarked
 - ✅ Used in production environments
-
-See [IMPLEMENTATION_STATUS.md](./IMPLEMENTATION_STATUS.md) for detailed feature tracking.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Remove broken IMPLEMENTATION_STATUS.md link that referenced a non-existent file
- Add test coverage badge (95.8%) to README badges section

## Changes
- Removed the reference to `IMPLEMENTATION_STATUS.md` from the Project Status section
- Added a coverage badge using shields.io showing 95.8% coverage

## Test plan
- [x] Verify README renders correctly
- [x] Confirm coverage badge displays properly
- [x] Check that broken link is removed