### PR TITLE
feat: add OPTIONS HTTP verb support for CORS preflight

### DIFF
--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -235,6 +235,16 @@ func NewMCPHandler(handleFunc func(context.Context, []byte) ([]byte, error)) *MC
 
 // ServeHTTP implements http.Handler
 func (h *MCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Handle CORS preflight
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key, Authorization")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -233,6 +233,39 @@ func TestMCPHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestMCPHandler_ServeHTTP_Options(t *testing.T) {
+	handleFunc := func(ctx context.Context, data []byte) ([]byte, error) {
+		return []byte(`{"result": "ok"}`), nil
+	}
+
+	handler := NewMCPHandler(handleFunc)
+
+	req := httptest.NewRequest("OPTIONS", "/mcp", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin *, got %s", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Methods") != "POST, OPTIONS" {
+		t.Errorf("expected Access-Control-Allow-Methods 'POST, OPTIONS', got %s", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Headers") != "Content-Type, X-API-Key, Authorization" {
+		t.Errorf("expected Access-Control-Allow-Headers 'Content-Type, X-API-Key, Authorization', got %s", w.Header().Get("Access-Control-Allow-Headers"))
+	}
+
+	if w.Header().Get("Access-Control-Max-Age") != "86400" {
+		t.Errorf("expected Access-Control-Max-Age '86400', got %s", w.Header().Get("Access-Control-Max-Age"))
+	}
+}
+
 func TestMCPHandler_ServeHTTP_HandleFuncError(t *testing.T) {
 	handleFunc := func(ctx context.Context, data []byte) ([]byte, error) {
 		return nil, io.ErrUnexpectedEOF

--- a/transport/sse/sse.go
+++ b/transport/sse/sse.go
@@ -219,6 +219,16 @@ func (s *Server) ListenAndServe() error {
 
 // handleSSE handles SSE requests
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	// Handle CORS preflight
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key, Authorization")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	// Set SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")

--- a/transport/sse/sse_test.go
+++ b/transport/sse/sse_test.go
@@ -221,3 +221,36 @@ func TestServer_handleSSE_GET(t *testing.T) {
 		t.Errorf("Expected text/event-stream, got %s", resp.Header.Get("Content-Type"))
 	}
 }
+
+func TestServer_handleSSE_OPTIONS(t *testing.T) {
+	handler := NewMCPSSEHandler(func(ctx context.Context, req []byte) ([]byte, error) {
+		return []byte(`{"status":"ok"}`), nil
+	})
+
+	server := NewServer(":0", handler)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	w := httptest.NewRecorder()
+
+	server.handleSSE(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin *, got %s", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Methods") != "GET, POST, OPTIONS" {
+		t.Errorf("expected Access-Control-Allow-Methods 'GET, POST, OPTIONS', got %s", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Headers") != "Content-Type, X-API-Key, Authorization" {
+		t.Errorf("expected Access-Control-Allow-Headers 'Content-Type, X-API-Key, Authorization', got %s", w.Header().Get("Access-Control-Allow-Headers"))
+	}
+
+	if w.Header().Get("Access-Control-Max-Age") != "86400" {
+		t.Errorf("expected Access-Control-Max-Age '86400', got %s", w.Header().Get("Access-Control-Max-Age"))
+	}
+}

--- a/transport/streamhttp/streamhttp.go
+++ b/transport/streamhttp/streamhttp.go
@@ -485,6 +485,20 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Handle CORS preflight
+	if r.Method == http.MethodOptions {
+		allowedOrigin := "*"
+		if s.allowedOrigin != "" {
+			allowedOrigin = s.allowedOrigin
+		}
+		w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, X-API-Key, Authorization, Last-Event-ID")
+		w.Header().Set("Access-Control-Max-Age", "86400")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
 		s.handlePOST(w, r)

--- a/transport/streamhttp/streamhttp_test.go
+++ b/transport/streamhttp/streamhttp_test.go
@@ -69,6 +69,56 @@ func TestServer_ServeHTTP_ForbiddenOrigin(t *testing.T) {
 	}
 }
 
+func TestServer_ServeHTTP_Options(t *testing.T) {
+	server := NewServer(":8080", nil)
+
+	req := httptest.NewRequest("OPTIONS", "/mcp", nil)
+	w := httptest.NewRecorder()
+
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin *, got %s", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Methods") != "GET, POST, OPTIONS" {
+		t.Errorf("expected Access-Control-Allow-Methods 'GET, POST, OPTIONS', got %s", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Headers") != "Content-Type, Mcp-Session-Id, X-API-Key, Authorization, Last-Event-ID" {
+		t.Errorf("expected correct headers, got %s", w.Header().Get("Access-Control-Allow-Headers"))
+	}
+
+	if w.Header().Get("Access-Control-Max-Age") != "86400" {
+		t.Errorf("expected Access-Control-Max-Age '86400', got %s", w.Header().Get("Access-Control-Max-Age"))
+	}
+}
+
+func TestServer_ServeHTTP_OptionsWithAllowedOrigin(t *testing.T) {
+	server := NewServer(":8080", nil, WithAllowedOrigin("http://allowed.com"))
+
+	req := httptest.NewRequest("OPTIONS", "/mcp", nil)
+	w := httptest.NewRecorder()
+
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://allowed.com" {
+		t.Errorf("expected Access-Control-Allow-Origin 'http://allowed.com', got %s", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Methods") != "GET, POST, OPTIONS" {
+		t.Errorf("expected Access-Control-Allow-Methods 'GET, POST, OPTIONS', got %s", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+}
+
 func TestSessionStore_GetOrCreate(t *testing.T) {
 	store := NewSessionStore()
 


### PR DESCRIPTION
## Summary
Adds OPTIONS method support to all HTTP-based transports (http, streamhttp, sse) to enable CORS preflight requests from browsers.

## Changes
- **transport/http**: Add OPTIONS handler with CORS headers
- **transport/streamhttp**: Add OPTIONS handler respecting `WithAllowedOrigin` config
- **transport/sse**: Add OPTIONS handler with CORS headers
- All transports return 204 No Content with appropriate CORS headers
- Add comprehensive tests for OPTIONS handling in all transports

## CORS Headers
- `Access-Control-Allow-Origin`: Configurable in streamhttp (via `WithAllowedOrigin`), `*` otherwise
- `Access-Control-Allow-Methods`: `GET, POST, OPTIONS` (based on transport)
- `Access-Control-Allow-Headers`: Includes MCP-specific headers (Content-Type, X-API-Key, Authorization, Mcp-Session-Id, Last-Event-ID)
- `Access-Control-Max-Age`: 86400 seconds (24 hours)

## Testing
- ✅ All existing tests pass
- ✅ New tests added for OPTIONS handling:
  - `TestMCPHandler_ServeHTTP_Options` (http)
  - `TestServer_ServeHTTP_Options` (streamhttp)
  - `TestServer_ServeHTTP_OptionsWithAllowedOrigin` (streamhttp)
  - `TestServer_handleSSE_OPTIONS` (sse)
- ✅ No linter errors

## Motivation
Browsers send OPTIONS preflight requests for cross-origin requests. Without OPTIONS support, CORS requests to MCP servers would fail even with proper CORS headers on other methods.