### PR TITLE
fix: prevent error responses for JSON-RPC notifications

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -163,6 +163,12 @@ func (s *Server) HandleMessage(ctx context.Context, msg *mcp.Message) *mcp.Messa
 		return handler(ctx, msg)
 	}
 
+	// Don't send error responses for notifications (messages without ID)
+	// Per JSON-RPC 2.0 spec, notifications must not receive any response
+	if msg.ID == nil {
+		return nil
+	}
+
 	return s.errorResponse(msg.ID, mcp.MethodNotFound, "method not found")
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -376,3 +376,60 @@ func TestServer_InvalidParams(t *testing.T) {
 		t.Errorf("expected error code %d, got %d", mcp.InvalidParams, response.Error.Code)
 	}
 }
+
+func TestServer_NotificationInitialized(t *testing.T) {
+	srv := New("test-server")
+
+	// Send notifications/initialized notification (no ID)
+	msg := &mcp.Message{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	}
+
+	response := srv.HandleMessage(context.Background(), msg)
+	// Notifications should not receive any response
+	if response != nil {
+		t.Errorf("expected no response for notification, got %+v", response)
+	}
+}
+
+func TestServer_UnknownNotification(t *testing.T) {
+	srv := New("test-server")
+
+	// Send unknown notification (no ID)
+	msg := &mcp.Message{
+		JSONRPC: "2.0",
+		Method:  "notifications/unknown",
+	}
+
+	response := srv.HandleMessage(context.Background(), msg)
+	// Notifications should not receive error responses
+	if response != nil {
+		t.Errorf("expected no response for unknown notification, got %+v", response)
+	}
+}
+
+func TestServer_UnknownRequest(t *testing.T) {
+	srv := New("test-server")
+
+	// Send unknown request (with ID)
+	msg := &mcp.Message{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "unknown/method",
+	}
+
+	response := srv.HandleMessage(context.Background(), msg)
+	// Requests should receive error responses
+	if response == nil {
+		t.Fatal("expected error response for unknown request")
+	}
+
+	if response.Error == nil {
+		t.Fatal("expected error in response")
+	}
+
+	if response.Error.Code != int(mcp.MethodNotFound) {
+		t.Errorf("expected error code %d, got %d", mcp.MethodNotFound, response.Error.Code)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes JSON-RPC 2.0 compliance issue where the server incorrectly sends error responses to notifications (messages without an ID field). Per the JSON-RPC 2.0 specification, notifications must not receive any response, including error responses.

## Problem
When a client sends a notification like `{"method":"notifications/initialized","jsonrpc":"2.0"}` (note: no ID field), the server was responding with a "method not found" error. This violates the JSON-RPC 2.0 spec which states that notifications are one-way messages that must not receive any response.

This was particularly problematic for:
- `notifications/initialized` sent by MCP clients after initialization
- Any other unknown notifications from clients
- CORS-enabled clients that would fail due to unexpected error responses

## Changes
- Modified `HandleMessage()` in `server/server.go` to check if `msg.ID` is nil before sending error response
- Notifications (messages without ID) now correctly receive no response
- Requests (messages with ID) still receive error responses for unknown methods
- Added comprehensive test coverage:
  - `TestServer_NotificationInitialized`: verifies no response for `notifications/initialized`
  - `TestServer_UnknownNotification`: verifies no error response for unknown notifications
  - `TestServer_UnknownRequest`: ensures requests still get error responses (regression test)

## Test plan
- [x] All existing tests pass
- [x] New tests verify notifications receive no response
- [x] New tests verify requests still receive error responses
- [x] Linter passes (`golangci-lint run ./server/...`)
- [x] Complies with JSON-RPC 2.0 specification